### PR TITLE
PyTorch 1.11.0 compatibility updates (see  yolov5)

### DIFF
--- a/models/experimental.py
+++ b/models/experimental.py
@@ -109,6 +109,8 @@ def attempt_load(weights, map_location=None, inplace=True, fuse=True):
                     setattr(m, 'anchor_grid', [torch.zeros(1)] * m.nl)
         elif type(m) is Conv:
             m._non_persistent_buffers_set = set()  # pytorch 1.6.0 compatibility
+        elif type(m) is nn.Upsample and not hasattr(m, 'recompute_scale_factor'):
+            m.recompute_scale_factor = None  # torch 1.11.0 compatibility
 
     if len(model) == 1:
         return model[-1]  # return model


### PR DESCRIPTION
Hi, we ran into an AttributeError running inference with detect.py due to a change of the PyTorch API in version 1.11 (no more "recompute_scale_factor"). So we added this fix according to the official [yolov5 "PyTorch 1.11.0 compatibility update"](https://github.com/ultralytics/yolov5/pull/6932/files).